### PR TITLE
Rework Contributing guidelines

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _site/**
 .jekyll-cache/**
-.bundle
 vendor

--- a/README.md
+++ b/README.md
@@ -1,17 +1,7 @@
 # My Recipe Website
-This is the repo for my recipe website, which can be viewed [here](https://dwdwdan.github.io/recipes/).
-If you have any recipes that you want to add feel free to submit a pull request if you know how to. If not feel free to
-email me (or message me on socials if you know me personally) and I'll either help guide you through it or convert something for you.
-
-## Contributing
-Contribution must be added to the `_posts` folder with the name `YYYY-MM-DD-Post-Title.md`, replacing the post title with
-an appropriate name for your recipe.
-
-The file has to start with the frontmatter
-```yaml
----
-title: Recipe Name
----
-```
-After this you have freedome to use markdown however you wish, but you should try to follow a similar style to the posts
-already in the `_posts` folder.
+This is the repo for my recipe website, which can be viewed
+[here](https://dwdwdan.github.io/recipes/).  If you have any recipes
+that you want to add feel free to submit a pull request if you know
+how to. If not feel free to email me (or message me on socials if you
+know me personally) and I'll either help guide you through it or
+convert something for you. A more detailed contributing guide can be found in [contributing.md](contributing.md).

--- a/contributing.md
+++ b/contributing.md
@@ -40,3 +40,26 @@ Adapted from [source_name](source_link)
 ```
 with the last line of course being optional.
 The short description from the frontmatter will be automatically displayed below the recipe's title along with the author and date.
+
+## Checking the generated output
+It is not necessary for you to check the recipe looks good in the website (I will always do this before authorising a PR anyway), but if you want to, here are some instructions:
+
+First, you will need to have ruby and rubygems installed (see [rubygems.org](rubygems.org)). For me, on fedora linux, this can be done with
+```
+$ sudo dnf install ruby rubygems
+```
+Then, use the gem package manager to install bundler
+```
+$ sudo gem install bundler
+```
+There is a config file for bundler included in this repository, so then you should be able to run
+```
+$ bundle install
+```
+to install all dependencies.
+
+Finally, you can tell jekyll to serve the website using
+```
+$ bundle exec jekyll serve
+```
+this will give you a web address that the website is being served at, probably beginning with `localhost`. If you additionally include the `-l` flag to the `bundle exec` command, your browser will automatically reload when you make changes to the files.


### PR DESCRIPTION
- Removes contrib guidelines in README, instead sending users to `contributing.md`
- Expands instructions in `contributing.md` to include instructions on jekyll
- Include default config file for bundle to install in local directory